### PR TITLE
Fixup permissions on cockpit.conf

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -30,12 +30,17 @@ ynh_change_url_nginx_config
 #=================================================
 # UPDATE A CONFIG FILE
 #=================================================
+ynh_script_progression --message="Fixing up permissions..." --weight=1
+
+usermod -a -G cockpit cockpit-ws
+usermod -a -G cockpit cockpit-wsinstance
+
 ynh_script_progression --message="Updating a configuration file..." --weight=1
 
 ynh_add_config --template="../conf/cockpit.conf" --destination="/etc/cockpit/cockpit.conf"
 
 chmod 650 "/etc/cockpit/cockpit.conf"
-chown root:$app-ws "/etc/cockpit/cockpit.conf"
+chown root:$app "/etc/cockpit/cockpit.conf"
 
 #=================================================
 # GENERIC FINALISATION

--- a/scripts/install
+++ b/scripts/install
@@ -22,6 +22,11 @@ ynh_add_nginx_config
 #=================================================
 # ADD A CONFIGURATION
 #=================================================
+ynh_script_progression --message="Fixing up permissions..." --weight=1
+
+usermod -a -G cockpit cockpit-ws
+usermod -a -G cockpit cockpit-wsinstance
+
 ynh_script_progression --message="Adding a configuration file..." --weight=1
 
 ynh_replace_string --match_string="ListenStream=.*" --replace_string="ListenStream=$port" --target_file="/lib/systemd/system/cockpit.socket"
@@ -31,7 +36,7 @@ systemctl restart $app.socket
 ynh_add_config --template="../conf/cockpit.conf" --destination="/etc/cockpit/cockpit.conf"
 
 chmod 650 "/etc/cockpit/cockpit.conf"
-chown root:$app-ws "/etc/cockpit/cockpit.conf"
+chown root:$app "/etc/cockpit/cockpit.conf"
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -13,6 +13,11 @@ source /usr/share/yunohost/helpers
 #=================================================
 # RESTORE VARIOUS FILES
 #=================================================
+ynh_script_progression --message="Fixing up permissions..." --weight=1
+
+usermod -a -G cockpit cockpit-ws
+usermod -a -G cockpit cockpit-wsinstance
+
 ynh_script_progression --message="Restoring various files..." --weight=1
 
 ynh_replace_string --match_string="ListenStream=.*" --replace_string="ListenStream=$port" --target_file="/lib/systemd/system/cockpit.socket"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -37,6 +37,11 @@ yunohost service add $app --description="Sysadmin login session in a web browser
 #=================================================
 # UPDATE A CONFIG FILE
 #=================================================
+ynh_script_progression --message="Fixing up permissions..." --weight=1
+
+usermod -a -G cockpit cockpit-ws
+usermod -a -G cockpit cockpit-wsinstance
+
 ynh_script_progression --message="Updating a configuration file..." --weight=1
 
 ynh_replace_string --match_string="ListenStream=.*" --replace_string="ListenStream=$port" --target_file="/lib/systemd/system/cockpit.socket"
@@ -46,7 +51,7 @@ systemctl restart $app.socket
 ynh_add_config --template="../conf/cockpit.conf" --destination="/etc/cockpit/cockpit.conf"
 
 chmod 650 "/etc/cockpit/cockpit.conf"
-chown root:$app-ws "/etc/cockpit/cockpit.conf"
+chown root:$app "/etc/cockpit/cockpit.conf"
 
 #=================================================
 # START SYSTEMD SERVICE


### PR DESCRIPTION
## Problem

There's an issue #16 open.

## Solution

- permission to read `/etc/cockipt/cockpit.conf` was only granted to group `cockpit-ws` while in fact user `cockpit-wsinstance` need that permission as well. Given we implicitly provision group `cockpit` let's add these 2 users there and grant ownership to `cockpit` group instead.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
